### PR TITLE
Remove LLM background knowledge filler from responses

### DIFF
--- a/src/prompts/resolve_and_route.md
+++ b/src/prompts/resolve_and_route.md
@@ -40,6 +40,7 @@ Top 5 studies ranked by: keyword match count (primary) → sample count (seconda
 ### Study Selection
 
 - **Multiple TCGA versions exist** for many cancer types. When intent is unclear, prefer the **PanCancer Atlas** version (e.g., `luad_tcga_pan_can_atlas_2018`).
+- **Broad disease terms → prefer pan-disease studies.** When the user queries a general disease category (e.g., "glioma", "sarcoma", "lymphoma"), prefer studies that cover the full disease spectrum over subtype-specific studies. For example, "glioma" encompasses both low-grade glioma (LGG) and glioblastoma (GBM), so `lgggbm_tcga_pub` (LGG+GBM combined) is more appropriate than `gbm_tcga` (GBM only). Similarly, prefer combined/pan-disease studies when the query does not specify a particular subtype.
 - **Pan-cancer studies** (e.g., MSK-CHORD) may match disease-specific queries — consider whether the user wants a disease-specific or cross-cancer study.
 - **No matches →** guide user to browse at https://www.cbioportal.org (studies from TCGA, ICGC, TARGET, institutional studies, cell line data)
 


### PR DESCRIPTION
## Summary
- Add "No Background Knowledge" section to system prompt that explicitly forbids LLM-sourced content like "what you'll find" sections, feature explanations, and study content summaries
- Strengthen "Link First" section to require direct tab URLs via the `tab` parameter instead of telling users to "click on the Mutations tab"
- Navigator responses should contain only: direct URLs, brief tool-sourced context (study name, sample count), and disambiguation questions

## Motivation
User feedback (Tali Mazor) reported that the navigator adds "what you'll find" sections pulling from LLM background knowledge instead of just providing cBioPortal links. It also explains how to navigate to tabs instead of linking directly to them.

## Test plan
- [ ] Verify queries like "KRAS mutations in lung cancer" return direct Mutations tab links (not instructions to click on the tab)
- [ ] Verify responses do not contain "what you'll find" or "what to expect" sections
- [ ] Verify responses do not explain what cBioPortal features do

🤖 Generated with [Claude Code](https://claude.com/claude-code)