### PR TITLE
Prefer study view with gene filter as primary link for gene queries

### DIFF
--- a/src/prompts/resolve_and_route.md
+++ b/src/prompts/resolve_and_route.md
@@ -94,6 +94,9 @@ Covers two sub-scenarios:
 - "TP53 mutation vs CDKN1A expression" → tab: `comparison/mrna`
 - "BRCA1 deletion and survival" → tab: `comparison/survival`
 
+**Gene-in-disease pattern — call BOTH study view and results view:**
+When the user asks about a specific gene in a disease or study context (e.g., "tell me about IDH1 mutations in glioma", "TP53 in lung cancer", "BRCA1 alterations in breast cancer"), call **both** `navigate_to_study_view` (with the gene as a mutation/CNA filter) **and** `navigate_to_results_view` in parallel. Present the **study view link first** — it gives the cohort overview with the gene filter applied (demographics, clinical distributions, sample counts). Present the **results view link second** — it provides the detailed gene analysis (mutation table, OncoPrint, cancer type summary). This gives the user a complete picture: cohort context first, then gene-level detail.
+
 **Key signal — "alteration":** The word "alteration" means mutation + CNA combined. StudyView filters treat these separately (mutationDataFilters vs cnaGeneFilters), making it hard to express. ResultsView handles alteration as a unified concept — altered vs unaltered grouping is built in. When the user says "alteration", strongly prefer `navigate_to_results_view`.
 
 **Key distinction — "vs" semantics:**

--- a/src/prompts/system.md
+++ b/src/prompts/system.md
@@ -26,6 +26,8 @@ Returns exact valid values for clinical attributes and generic assay entities. R
 
 You may call **multiple navigation tools in parallel** when the query spans multiple views. For example, when a comparison query mentions specific genes, call both `navigate_to_group_comparison` and `navigate_to_results_view` to give the user both perspectives.
 
+**Gene-in-disease queries:** When the user asks about a specific gene in a disease or study context (e.g., "TP53 in glioma", "IDH1 mutations in low-grade glioma"), call **both** `navigate_to_study_view` (with gene filter) **and** `navigate_to_results_view` in parallel. Present the study view link **first** (cohort overview with gene filter applied) and the results view link **second** (detailed gene analysis). Study view gives the big picture of the filtered cohort; results view gives gene-level detail.
+
 ### Companion URLs
 Navigation tools may return a `studyViewUrl` alongside the primary `url`. When present, offer both to the user — the primary link for the main analysis, and the StudyView link for exploring the cohort.
 


### PR DESCRIPTION
## Summary
- When a user asks about a specific gene in a disease/study context (e.g., "TP53 in glioma"), the navigator now calls **both** `navigate_to_study_view` (with gene filter) and `navigate_to_results_view` in parallel
- Study view link is presented **first** (cohort overview with gene filter applied), results view link **second** (detailed gene analysis)
- Updated guidance in both `resolve_and_route.md` (Rule 3, gene-in-disease pattern) and `system.md` (Tool Workflow section)

## Context
User feedback from Tali Mazor: when asking about TP53 in glioma, the navigator returned 2 results view links. The preferred behavior is to first provide a study view link with TP53 filter applied (for cohort overview), then the results view link (for detailed gene analysis like mutations tab or cancer types summary).

## Test plan
- [ ] Ask "tell me about TP53 in glioma" — should return study view link first, results view link second
- [ ] Ask "IDH1 mutations in low-grade glioma" — should return both study view (with IDH1 filter) and results view
- [ ] Ask "BRCA1 alterations in breast cancer" — should return study view + results view
- [ ] Verify existing queries still work (e.g., "compare male vs female in LUAD" should still use group comparison)

🤖 Generated with [Claude Code](https://claude.com/claude-code)