### PR TITLE
Prefer broader disease studies when query uses general disease terms

### DIFF
--- a/src/prompts/resolve_and_route.md
+++ b/src/prompts/resolve_and_route.md
@@ -40,6 +40,7 @@ Top 5 studies ranked by: keyword match count (primary) → sample count (seconda
 ### Study Selection
 
 - **Multiple TCGA versions exist** for many cancer types. When intent is unclear, prefer the **PanCancer Atlas** version (e.g., `luad_tcga_pan_can_atlas_2018`).
+- **Broad disease terms → prefer pan-disease studies.** When the user queries a general disease category (e.g., "glioma", "sarcoma", "lymphoma"), prefer studies that cover the full disease spectrum over subtype-specific studies. For example, "glioma" encompasses both low-grade glioma (LGG) and glioblastoma (GBM), so `lgggbm_tcga_pub` (LGG+GBM combined) is more appropriate than `gbm_tcga` (GBM only). Similarly, prefer combined/pan-disease studies when the query does not specify a particular subtype.
 - **Pan-cancer studies** (e.g., MSK-CHORD) may match disease-specific queries — consider whether the user wants a disease-specific or cross-cancer study.
 - **No matches →** guide user to browse at https://www.cbioportal.org (studies from TCGA, ICGC, TARGET, institutional studies, cell line data)
 


### PR DESCRIPTION
## Summary

- Add guidance in the Study Selection section of `resolve_and_route.md` to prefer pan-disease studies when the user queries a broad disease category
- For example, when a user asks about "glioma", the navigator should prefer `lgggbm_tcga_pub` (LGG+GBM combined) over `gbm_tcga` (GBM only), since glioma encompasses both low-grade glioma and glioblastoma

## Context

User feedback from Tali Mazor: when she asked "tell me about IDH1 mutations in glioma", the navigator picked a GBM-specific study instead of the pan-glioma study `lgggbm_tcga_pub`. The existing prompt already had guidance about preferring PanCancer Atlas for ambiguous TCGA versions, but lacked guidance about disease hierarchy — preferring broader studies when the query uses a general disease term.

## Test plan

- [ ] Ask "tell me about IDH1 mutations in glioma" and verify `lgggbm_tcga_pub` is selected over `gbm_tcga`
- [ ] Ask about a specific subtype (e.g., "GBM mutations") and verify it still selects the subtype-specific study
- [ ] Ask about other broad categories (e.g., "sarcoma", "lymphoma") and verify broader studies are preferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)