### PR TITLE
fix(http): return 405 on GET/DELETE /mcp to stop MCP client reconnect storm

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -47,7 +47,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=sha,prefix={{branch}}-
+            type=sha,prefix={{branch}}-,enable=${{ github.event_name != 'pull_request' }}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ async function startHttp() {
         });
     });
 
-    app.all('/mcp', async (req, res) => {
+    app.post('/mcp', async (req, res) => {
         try {
             const server = createMcpServer();
             const transport = new StreamableHTTPServerTransport({
@@ -102,6 +102,23 @@ async function startHttp() {
             }
         }
     });
+
+    // This stateless server only implements request/response over POST. It sends
+    // no server-initiated messages, so it does not offer the optional standalone
+    // SSE stream (GET) or session teardown (DELETE). Responding 405 tells MCP
+    // clients to skip the standalone stream; otherwise they treat the dropped
+    // stream as a failure and reconnect indefinitely.
+    const methodNotAllowed = (_req: express.Request, res: express.Response) => {
+        res.status(405)
+            .set('Allow', 'POST')
+            .json({
+                jsonrpc: '2.0',
+                error: { code: -32000, message: 'Method not allowed.' },
+                id: null,
+            });
+    };
+    app.get('/mcp', methodNotAllowed);
+    app.delete('/mcp', methodNotAllowed);
 
     const port = parseInt(process.env.PORT || '8002');
     const server = app.listen(port, () => {


### PR DESCRIPTION
## Problem

The remote MCP server (HTTP/Streamable transport) causes connected MCP clients to **reconnect in a tight loop**. In production, the LibreChat agent that connects to this navigator logs a steady stream of:

```
[MCP][cbioportal-navigator] Transport error (may require manual intervention): SSE stream disconnected: TypeError: terminated
[MCP][cbioportal-navigator] Reconnecting 1/3 (delay: ~2-3s)
[MCP][cbioportal-navigator] Transport error: SSE stream disconnected: AbortError: This operation was aborted
[MCP][cbioportal-navigator] Streamable-http transport closed
```

Observed volume: **~19,900 transport errors over 2 days (~10k/day)** from the LibreChat clients pointed at this server. Tool calls still work, but the connection churns constantly.

## Root cause

`startHttp()` registers the MCP endpoint with `app.all('/mcp', …)` and runs the transport **statelessly** (`sessionIdGenerator: undefined`), creating a fresh `StreamableHTTPServerTransport` + `McpServer` per request.

Per the MCP Streamable HTTP spec, the client opens a long-lived **`GET /mcp`** request to receive server-initiated messages (the "standalone SSE stream"). Because of `app.all`, that GET is routed into the transport, and the SDK's `handleGetRequest` opens a `text/event-stream` response and holds it open — but it is bound to a throwaway, session-less transport, so it is never usable and gets torn down. The client's `StreamableHTTPClientTransport` treats the dropped stream as a failure and reconnects indefinitely.

Reproduced directly against `master`:

```
$ curl -m 3 -D - -H 'Accept: text/event-stream' http://localhost:8002/mcp
HTTP/1.1 200 OK
content-type: text/event-stream
connection: keep-alive
Transfer-Encoding: chunked
curl: (28) Operation timed out … with 0 bytes received   # held open forever, sends nothing
```

In the SDK client (`@modelcontextprotocol/sdk` 1.26.0, `client/streamableHttp.ts`), a **405** response to that GET makes the client skip the standalone stream and `return` gracefully — no reconnect. Any other outcome (including a 200 stream that later drops) schedules reconnection.

## Fix

This server sends **no** server-initiated messages and uses `enableJsonResponse: true`, so it does not need the standalone SSE stream at all. Serve `POST /mcp` via the transport, and return **405** on `GET`/`DELETE` — matching the SDK's own stateless server example.

```ts
app.post('/mcp', async (req, res) => { /* unchanged */ });

const methodNotAllowed = (_req, res) =>
  res.status(405).set('Allow', 'POST').json({
    jsonrpc: '2.0', error: { code: -32000, message: 'Method not allowed.' }, id: null,
  });
app.get('/mcp', methodNotAllowed);
app.delete('/mcp', methodNotAllowed);
```

## Precedent

This is exactly the SDK's own stateless server example — [`src/examples/server/simpleStatelessStreamableHttp.ts`](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/examples/server/simpleStatelessStreamableHttp.ts) — which serves `POST /mcp` and returns `405 Method not allowed.` for both `GET` and `DELETE`. `app.all('/mcp', …)` is the shape used by the *stateful* example (`simpleStreamableHttp.ts`), where a `transports[sessionId]` map lets the GET request reuse the session's transport and actually serve the SSE stream. This server runs statelessly (`sessionIdGenerator: undefined`, new transport per request) and sends no server-initiated messages (`enableJsonResponse: true`), so the stateless pattern is the correct match. (If server→client streaming/notifications are ever needed, the alternative is to go fully stateful with a session map rather than route GET into a session-less transport.)

## Verification (after fix, same build)

```
GET /mcp     -> 405 Method Not Allowed (Allow: POST), returns immediately (no hang)
DELETE /mcp  -> 405
POST initialize -> 200 (JSON result)
POST tools/list -> 200, returns all 6 tools (resolve_and_route, navigate_to_study_view, …)
```

`tsc` build and Prettier both clean. Expected effect: the LibreChat clients stop opening the doomed GET stream, eliminating the reconnect storm; POST tool invocations are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

