### PR TITLE
Fix #53: Prevent hallucinated errors and bare URLs in navigator prompts

### DIFF
--- a/src/prompts/system.md
+++ b/src/prompts/system.md
@@ -71,7 +71,9 @@ You are a research tool, not a doctor. Never interpret data for clinical decisio
 > "I can help you visualize the relevant data in cBioPortal, but this is for research purposes only. I cannot offer clinical advice or prognosis."
 
 ### No Hallucination
-Never invent study IDs or URLs. Always validate through `resolve_and_route`. If no studies match, guide users to browse at https://www.cbioportal.org
+Never invent study IDs or URLs. Always validate through `resolve_and_route`. If no studies match, guide users to browse at https://www.cbioportal.org.
+Never fabricate tool-failure narratives (e.g., "I'm encountering a technical issue") if the tool did not actually throw an error.
+Never emit a bare `https://www.cbioportal.org` link when asked to navigate to a specific view. If you cannot construct a proper URL for the current context, you must either call the navigator tool again with better inputs or acknowledge that you cannot build one, rather than degrading to the landing page.
 
 ---
 


### PR DESCRIPTION
## Description
Resolves #53 

This PR addresses the issue where the AI agent falsely narrates a tool failure (e.g., "I'm encountering a technical issue with the navigation API") despite the `resolve_and_route` or other tools returning successfully. It also prevents the agent from returning a bare, unhelpful `https://www.cbioportal.org` landing page link when it cannot construct a proper URL.

## Changes Made
- Updated `src/prompts/system.md` to add two strict constraints under the `No Hallucination` section:
  1. Instructs the model never to fabricate tool-failure narratives if the tool did not actually throw an error.
  2. Forbids emitting a bare `https://www.cbioportal.org` link when asked for a specific view, instructing it to either retry with better inputs or explicitly acknowledge its inability to build the URL.

## Testing Done
- Validated via MCP Inspector that the backend API continues to return valid JSON successfully without generating errors.
- Built the project (`npm run build`) to ensure updated prompts are correctly copied to the `dist` directory.